### PR TITLE
Create order response

### DIFF
--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,3 +1,7 @@
 class Order < ApplicationRecord
   has_many :order_items
+  
+  def order_total
+    order_items.joins(:product).sum("products.price")
+  end
 end

--- a/app/serializers/order_serializer.rb
+++ b/app/serializers/order_serializer.rb
@@ -1,14 +1,10 @@
 class OrderSerializer < ActiveModel::Serializer
-  attributes :id, :products, :total, :order_total
+  attributes :id, :products, :order_total
 
   def products
     object.order_items.group_by(&:product_id).map do |_key, value|
       product = value.uniq(&:product_id)[0].product
       { amount: value.size, title: product.title, price: (value.size * product.price), product_id: product.id }
     end
-  end
-
-  def total
-    object.order_items.joins(:product).sum('products.price')
   end
 end

--- a/app/serializers/order_serializer.rb
+++ b/app/serializers/order_serializer.rb
@@ -1,14 +1,14 @@
 class OrderSerializer < ActiveModel::Serializer
-  attributes :id, :products, :order_total
+  attributes :id, :products, :total, :order_total
 
   def products
     object.order_items.group_by(&:product_id).map do |_key, value|
       product = value.uniq(&:product_id)[0].product
-      { amount: value.size, title: product.title, price: (value.size * product.price) }
+      { amount: value.size, title: product.title, price: (value.size * product.price), product_id: product.id }
     end
   end
 
-  def order_total
+  def total
     object.order_items.joins(:product).sum('products.price')
   end
 end

--- a/spec/requests/api/v1/orders_controller_spec.rb
+++ b/spec/requests/api/v1/orders_controller_spec.rb
@@ -47,5 +47,9 @@ RSpec.describe Api::V1::OrdersController, type: :request do
     it "responds with the right order total" do
       expect(response_json['order']['order_total']).to eq 330
     end
+
+    it "responds with product id" do
+      expect(response_json['order']['products'][0]['product_id']).to eq product_1.id
+    end
   end
 end


### PR DESCRIPTION
[PT Link](https://www.pivotaltracker.com/story/show/172642009)

Proposed changes in this PR: 

*  Adding `product_id` to serializer response
*  Removing the `total` method from it, since it doesn't hold any value currently and we do that calculation in front-end currently